### PR TITLE
Add "strings" to Internal Data Structures

### DIFF
--- a/_content/tour/variables.article
+++ b/_content/tour/variables.article
@@ -41,7 +41,7 @@ and pointers for a given architecture. For example:
 - 32 bit arch: word size is 4 bytes of memory allocation
 - 64 bit arch: word size is 8 bytes of memory allocation
 
-This is important because Go has internal data structures (maps, channels, slices,
+This is important because Go has internal data structures (strings, maps, channels, slices,
 interfaces, and functions) that store integers and pointers. The size of these data
 structures will be based on the architecture being used to build the program.
 


### PR DESCRIPTION
This pull request enhances clarity by including "strings" in the description of internal data structures. This adjustment ensures coherence with the following content.