### PR TITLE
fixed filter returning exercises pages

### DIFF
--- a/_content/tour/error-handling.article
+++ b/_content/tour/error-handling.article
@@ -418,7 +418,7 @@ to develop reliable systems." - Al Aho (inventor of AWK)
 - [[https://crawshaw.io/blog/xerrors][Go 1.13: xerrors]] - David Crawshaw  
 - [[https://rauljordan.com/2020/07/06/why-go-error-handling-is-awesome.html][Why Go's Error Handling is Awesome]] - Raul Jordan  
    
-* Excercise
+* Exercises
 
 Use the template as a starting point to complete the exercises. A possible solution is provided.
 

--- a/internal/tour/tour.go
+++ b/internal/tour/tour.go
@@ -130,8 +130,8 @@ func indexLessonsInto(index bleve.Index) error {
 // indexLessonInto indexes the pages of a lesson into the provided bleve index.
 func indexLessonInto(index bleve.Index, lessonName string, lsn lesson) error {
 	for pageNum, page := range lsn.Pages {
-		// Skip indexing "Exercises" pages.
-		if page.Title == "Exercises" {
+		// Skip indexing "Exercise" pages.
+		if strings.Contains(page.Title, "Exercise") {
 			continue
 		}
 


### PR DESCRIPTION
- Fixed page title that was causing the filter to fail;
- Improved the check to avoid indexing "Exercises" pages;