### PR TITLE
Remove broken link from context.article

### DIFF
--- a/_content/tour/context.article
+++ b/_content/tour/context.article
@@ -40,8 +40,6 @@ A solution provided by the Go team to solve this problem is the Context package.
 It was written and introduced by Sameer Ajmani back in 2014 at the Gotham Go
 conference. He also wrote a blog post for the Go blog.
 
-Talk Video: [[https://vimeo.com/115309491][https://vimeo.com/115309491]]
-
 Slide Deck: [[https://talks.golang.org/2014/gotham-context.slide#1][https://talks.golang.org/2014/gotham-context.slide#1]]
 
 Blog Post: [[https://blog.golang.org/context][https://blog.golang.org/context]]
@@ -512,7 +510,6 @@ layer using a Context, you have two problems:
 - [[https://www.ardanlabs.com/blog/2019/09/context-package-semantics-in-go.html][Context Package Semantics In Go]] - William Kennedy  
 - [[https://golang.org/pkg/context][Package context]] - Go Team    
 - [[https://blog.golang.org/context][Go Concurrency Patterns: Context]] - Sameer Ajmani    
-- [[https://vimeo.com/115309491][Cancellation, Context, and Plumbing]] - Sameer Ajmani    
 - [[https://rakyll.org/leakingctx/][Using contexts to avoid leaking goroutines]] - JBD    
 
 * Exercises


### PR DESCRIPTION
That talk is gone from Vimeo.
https://web.archive.org/web/20150211072846/https://vimeo.com/115309491
I was not able to find the re-uploaded version anywhere.

I am in contributors:
https://github.com/ardanlabs/gotour/blob/main/CONTRIBUTORS#L23