### PR TITLE
drop legacy build tag

### DIFF
--- a/_content/tour/algorithms/bits/iseven.go
+++ b/_content/tour/algorithms/bits/iseven.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/data/hash_map.go
+++ b/_content/tour/algorithms/data/hash_map.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/data/list.go
+++ b/_content/tour/algorithms/data/list.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/data/queue_circular.go
+++ b/_content/tour/algorithms/data/queue_circular.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/data/stack.go
+++ b/_content/tour/algorithms/data/stack.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/data/tree_binary.go
+++ b/_content/tour/algorithms/data/tree_binary.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/fun/barber.go
+++ b/_content/tour/algorithms/fun/barber.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/fun/freq_sequential.go
+++ b/_content/tour/algorithms/fun/freq_sequential.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/fun/vlq.go
+++ b/_content/tour/algorithms/fun/vlq.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 package main
 

--- a/_content/tour/algorithms/numbers/palindrome.go
+++ b/_content/tour/algorithms/numbers/palindrome.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/searches/binary_iterative.go
+++ b/_content/tour/algorithms/searches/binary_iterative.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/searches/binary_recursive.go
+++ b/_content/tour/algorithms/searches/binary_recursive.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/slices/max_number.go
+++ b/_content/tour/algorithms/slices/max_number.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/slices/min_number.go
+++ b/_content/tour/algorithms/slices/min_number.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/sorting/bubble.go
+++ b/_content/tour/algorithms/sorting/bubble.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/sorting/heap.go
+++ b/_content/tour/algorithms/sorting/heap.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/sorting/insertion.go
+++ b/_content/tour/algorithms/sorting/insertion.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/sorting/quick.go
+++ b/_content/tour/algorithms/sorting/quick.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/strings/palindrome.go
+++ b/_content/tour/algorithms/strings/palindrome.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/algorithms/strings/permutation.go
+++ b/_content/tour/algorithms/strings/permutation.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/arrays/answer1.go
+++ b/_content/tour/arrays/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/arrays/example1.go
+++ b/_content/tour/arrays/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/arrays/example2.go
+++ b/_content/tour/arrays/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/arrays/example3.go
+++ b/_content/tour/arrays/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/arrays/example4.go
+++ b/_content/tour/arrays/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/arrays/exercise1.go
+++ b/_content/tour/arrays/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/answer1.go
+++ b/_content/tour/channels/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/answer2.go
+++ b/_content/tour/channels/answer2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/answer3.go
+++ b/_content/tour/channels/answer3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/answer4.go
+++ b/_content/tour/channels/answer4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/example1.go
+++ b/_content/tour/channels/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/example10.go
+++ b/_content/tour/channels/example10.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/example2.go
+++ b/_content/tour/channels/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/example3.go
+++ b/_content/tour/channels/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/example4.go
+++ b/_content/tour/channels/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/example5.go
+++ b/_content/tour/channels/example5.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/example6.go
+++ b/_content/tour/channels/example6.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/example7.go
+++ b/_content/tour/channels/example7.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/example8.go
+++ b/_content/tour/channels/example8.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/example9.go
+++ b/_content/tour/channels/example9.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/exercise1.go
+++ b/_content/tour/channels/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/exercise2.go
+++ b/_content/tour/channels/exercise2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/exercise3.go
+++ b/_content/tour/channels/exercise3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/channels/exercise4.go
+++ b/_content/tour/channels/exercise4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/composition/assertions/example1.go
+++ b/_content/tour/composition/assertions/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/composition/assertions/example2.go
+++ b/_content/tour/composition/assertions/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/composition/assertions/example3.go
+++ b/_content/tour/composition/assertions/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/composition/decoupling/answer1.go
+++ b/_content/tour/composition/decoupling/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/composition/decoupling/example1.go
+++ b/_content/tour/composition/decoupling/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/composition/decoupling/example2.go
+++ b/_content/tour/composition/decoupling/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/composition/decoupling/example3.go
+++ b/_content/tour/composition/decoupling/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/composition/decoupling/example4.go
+++ b/_content/tour/composition/decoupling/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/composition/decoupling/example5.go
+++ b/_content/tour/composition/decoupling/example5.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/composition/decoupling/example6.go
+++ b/_content/tour/composition/decoupling/example6.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/composition/decoupling/exercise1.go
+++ b/_content/tour/composition/decoupling/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/composition/grouping/example1.go
+++ b/_content/tour/composition/grouping/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/composition/grouping/example2.go
+++ b/_content/tour/composition/grouping/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/composition/mocking/example1.go
+++ b/_content/tour/composition/mocking/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/composition/pollution/example1.go
+++ b/_content/tour/composition/pollution/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/composition/pollution/example2.go
+++ b/_content/tour/composition/pollution/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/constants/answer1.go
+++ b/_content/tour/constants/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/constants/example1.go
+++ b/_content/tour/constants/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/constants/example2.go
+++ b/_content/tour/constants/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/constants/example3.go
+++ b/_content/tour/constants/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/constants/example4.go
+++ b/_content/tour/constants/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/constants/exercise1.go
+++ b/_content/tour/constants/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/context/answer1.go
+++ b/_content/tour/context/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/context/example1.go
+++ b/_content/tour/context/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/context/example2.go
+++ b/_content/tour/context/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/context/example3.go
+++ b/_content/tour/context/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/context/example4.go
+++ b/_content/tour/context/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/context/example5.go
+++ b/_content/tour/context/example5.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/context/example6.go
+++ b/_content/tour/context/example6.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/context/exercise1.go
+++ b/_content/tour/context/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/data_race/answer1.go
+++ b/_content/tour/data_race/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/data_race/example1.go
+++ b/_content/tour/data_race/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/data_race/example2.go
+++ b/_content/tour/data_race/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/data_race/example3.go
+++ b/_content/tour/data_race/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/data_race/example4.go
+++ b/_content/tour/data_race/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/data_race/example5.go
+++ b/_content/tour/data_race/example5.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/data_race/example6.go
+++ b/_content/tour/data_race/example6.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/data_race/exercise1.go
+++ b/_content/tour/data_race/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/embedding/answer1.go
+++ b/_content/tour/embedding/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/embedding/example1.go
+++ b/_content/tour/embedding/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/embedding/example2.go
+++ b/_content/tour/embedding/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/embedding/example3.go
+++ b/_content/tour/embedding/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/embedding/example4.go
+++ b/_content/tour/embedding/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/embedding/exercise1.go
+++ b/_content/tour/embedding/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/error-handling/answer1.go
+++ b/_content/tour/error-handling/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/error-handling/answer2.go
+++ b/_content/tour/error-handling/answer2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/error-handling/example1.go
+++ b/_content/tour/error-handling/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/error-handling/example2.go
+++ b/_content/tour/error-handling/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/error-handling/example3.go
+++ b/_content/tour/error-handling/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/error-handling/example4.go
+++ b/_content/tour/error-handling/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/error-handling/example5.go
+++ b/_content/tour/error-handling/example5.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/error-handling/example6.go
+++ b/_content/tour/error-handling/example6.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/error-handling/exercise1.go
+++ b/_content/tour/error-handling/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/error-handling/exercise2.go
+++ b/_content/tour/error-handling/exercise2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/exporting/answer1.go
+++ b/_content/tour/exporting/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/exporting/example1.go
+++ b/_content/tour/exporting/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/exporting/example2.go
+++ b/_content/tour/exporting/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/exporting/example3.go
+++ b/_content/tour/exporting/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/exporting/example4.go
+++ b/_content/tour/exporting/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/exporting/example5.go
+++ b/_content/tour/exporting/example5.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/exporting/exercise1.go
+++ b/_content/tour/exporting/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/functions/answer1.go
+++ b/_content/tour/functions/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/functions/example1.go
+++ b/_content/tour/functions/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/functions/example2.go
+++ b/_content/tour/functions/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/functions/example3.go
+++ b/_content/tour/functions/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/functions/example4.go
+++ b/_content/tour/functions/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/functions/example5.go
+++ b/_content/tour/functions/example5.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/functions/exercise1.go
+++ b/_content/tour/functions/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/basics/answer1.go
+++ b/_content/tour/generics/basics/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/basics/example1.go
+++ b/_content/tour/generics/basics/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/basics/example2.go
+++ b/_content/tour/generics/basics/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/basics/example3.go
+++ b/_content/tour/generics/basics/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/basics/example4.go
+++ b/_content/tour/generics/basics/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/basics/exercise1.go
+++ b/_content/tour/generics/basics/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/behavior-constraints/answer1.go
+++ b/_content/tour/generics/behavior-constraints/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/behavior-constraints/example1.go
+++ b/_content/tour/generics/behavior-constraints/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/behavior-constraints/example2.go
+++ b/_content/tour/generics/behavior-constraints/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/behavior-constraints/example3.go
+++ b/_content/tour/generics/behavior-constraints/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/behavior-constraints/example4.go
+++ b/_content/tour/generics/behavior-constraints/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/behavior-constraints/exercise1.go
+++ b/_content/tour/generics/behavior-constraints/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/channels/example1.go
+++ b/_content/tour/generics/channels/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/channels/example2.go
+++ b/_content/tour/generics/channels/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/hash-table/example1.go
+++ b/_content/tour/generics/hash-table/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/multi-type-params/example1.go
+++ b/_content/tour/generics/multi-type-params/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/slice-constraints/example1.go
+++ b/_content/tour/generics/slice-constraints/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/struct-types/answer1.go
+++ b/_content/tour/generics/struct-types/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/struct-types/example1.go
+++ b/_content/tour/generics/struct-types/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/struct-types/exercise1.go
+++ b/_content/tour/generics/struct-types/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/type-constraints/answer1.go
+++ b/_content/tour/generics/type-constraints/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/type-constraints/example1.go
+++ b/_content/tour/generics/type-constraints/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/type-constraints/example2.go
+++ b/_content/tour/generics/type-constraints/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/type-constraints/example3.go
+++ b/_content/tour/generics/type-constraints/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/type-constraints/exercise1.go
+++ b/_content/tour/generics/type-constraints/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/underlying-types/answer1.go
+++ b/_content/tour/generics/underlying-types/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/underlying-types/example1.go
+++ b/_content/tour/generics/underlying-types/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/underlying-types/example2.go
+++ b/_content/tour/generics/underlying-types/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/underlying-types/example3.go
+++ b/_content/tour/generics/underlying-types/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/generics/underlying-types/exercise1.go
+++ b/_content/tour/generics/underlying-types/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/goroutines/answer1.go
+++ b/_content/tour/goroutines/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/goroutines/example1.go
+++ b/_content/tour/goroutines/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/goroutines/example2.go
+++ b/_content/tour/goroutines/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/goroutines/example3.go
+++ b/_content/tour/goroutines/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/goroutines/exercise1.go
+++ b/_content/tour/goroutines/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/interfaces/answer1.go
+++ b/_content/tour/interfaces/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/interfaces/example1.go
+++ b/_content/tour/interfaces/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/interfaces/example2.go
+++ b/_content/tour/interfaces/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/interfaces/example3.go
+++ b/_content/tour/interfaces/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/interfaces/example4.go
+++ b/_content/tour/interfaces/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/interfaces/example5.go
+++ b/_content/tour/interfaces/example5.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/interfaces/example6.go
+++ b/_content/tour/interfaces/example6.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/interfaces/example7.go
+++ b/_content/tour/interfaces/example7.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/interfaces/example8.go
+++ b/_content/tour/interfaces/example8.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/interfaces/example9.go
+++ b/_content/tour/interfaces/example9.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/interfaces/exercise1.go
+++ b/_content/tour/interfaces/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/maps/answer1.go
+++ b/_content/tour/maps/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/maps/example1.go
+++ b/_content/tour/maps/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/maps/example2.go
+++ b/_content/tour/maps/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/maps/example3.go
+++ b/_content/tour/maps/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/maps/example4.go
+++ b/_content/tour/maps/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/maps/example5.go
+++ b/_content/tour/maps/example5.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/maps/example6.go
+++ b/_content/tour/maps/example6.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/maps/example7.go
+++ b/_content/tour/maps/example7.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/maps/exercise1.go
+++ b/_content/tour/maps/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/methods/answer1.go
+++ b/_content/tour/methods/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/methods/example1.go
+++ b/_content/tour/methods/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/methods/example2.go
+++ b/_content/tour/methods/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/methods/example3.go
+++ b/_content/tour/methods/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/methods/example4.go
+++ b/_content/tour/methods/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/methods/example5.go
+++ b/_content/tour/methods/example5.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/methods/exercise1.go
+++ b/_content/tour/methods/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/pointers/answer1.go
+++ b/_content/tour/pointers/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/pointers/answer2.go
+++ b/_content/tour/pointers/answer2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/pointers/example1.go
+++ b/_content/tour/pointers/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/pointers/example2.go
+++ b/_content/tour/pointers/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/pointers/example3.go
+++ b/_content/tour/pointers/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/pointers/example4.go
+++ b/_content/tour/pointers/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/pointers/example5.go
+++ b/_content/tour/pointers/example5.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/pointers/exercise1.go
+++ b/_content/tour/pointers/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/pointers/exercise2.go
+++ b/_content/tour/pointers/exercise2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/slices/answer1.go
+++ b/_content/tour/slices/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/slices/example1.go
+++ b/_content/tour/slices/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/slices/example10.go
+++ b/_content/tour/slices/example10.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/slices/example2.go
+++ b/_content/tour/slices/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/slices/example3.go
+++ b/_content/tour/slices/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/slices/example4.go
+++ b/_content/tour/slices/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/slices/example5.go
+++ b/_content/tour/slices/example5.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/slices/example6.go
+++ b/_content/tour/slices/example6.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/slices/example7.go
+++ b/_content/tour/slices/example7.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/slices/example8.go
+++ b/_content/tour/slices/example8.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/slices/example9.go
+++ b/_content/tour/slices/example9.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/slices/exercise1.go
+++ b/_content/tour/slices/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/struct-types/answer1.go
+++ b/_content/tour/struct-types/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/struct-types/example1.go
+++ b/_content/tour/struct-types/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/struct-types/example2.go
+++ b/_content/tour/struct-types/example2.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/struct-types/example3.go
+++ b/_content/tour/struct-types/example3.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/struct-types/example4.go
+++ b/_content/tour/struct-types/example4.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/struct-types/exercise1.go
+++ b/_content/tour/struct-types/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/variables/answer1.go
+++ b/_content/tour/variables/answer1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/variables/example1.go
+++ b/_content/tour/variables/example1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/variables/exercise1.go
+++ b/_content/tour/variables/exercise1.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/_content/tour/welcome/hello.go
+++ b/_content/tour/welcome/hello.go
@@ -1,5 +1,4 @@
 //go:build OMIT
-// +build OMIT
 
 package main
 


### PR DESCRIPTION
drop deprecated `+ build` syntax for  tags
https://stackoverflow.com/a/68361186/1572363
https://pkg.go.dev/cmd/go#hdr-Build_constraints
https://go.dev/doc/go1.18#go-build-lines

This could've been done by the `go fix`:
```
$ cd _content
$ ~/code/go/bin/go fix -tags OMIT . ./...
```

But since some exercises are not compiling, I just did:
```
sed -i '\| +build OMIT|d'  $(rg -l '// \+build OMIT')
```

I am in contributors:
https://github.com/ardanlabs/gotour/blob/main/CONTRIBUTORS#L23
