### PR TITLE
Fix: parenthesis typo

### DIFF
--- a/_content/tour/eng/slices.article
+++ b/_content/tour/eng/slices.article
@@ -199,7 +199,7 @@ Slices provide the ability to avoid extra copies and heap allocations of the bac
 array when needing to isolate certain elements of the backing array for different
 operations.
 
-The slicing syntax represents the list notation [a:b) which means, include
+The slicing syntax represents the list notation [a:b] which means, include
 elements from index a through b, but not including b.
 
     slice1 := []string{"A", "B", "C", "D", "E"}


### PR DESCRIPTION
Add correct square bracket for the slices - slicing syntax description.