### PR TITLE
Use secure links for Go site

### DIFF
--- a/_content/tour/eng/error-handling.article
+++ b/_content/tour/eng/error-handling.article
@@ -39,7 +39,7 @@ can maintain any state or behavior.
 
 The error interface is built into the language. 
 
-    // http://golang.org/pkg/builtin/#error
+    // https://golang.org/pkg/builtin/#error
     type error interface {
         Error() string
     }
@@ -53,12 +53,12 @@ aspect of my application that is more susceptible to change and improvement.
 This interface is the type Go applications must use as the return type for error
 handling.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     type errorString struct {
         s string
     }
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func (e *errorString) Error() string {
         return e.s
     }
@@ -75,7 +75,7 @@ purpose of implementing the interface and for logging. If any user needs to pars
 the string returned from this method, You have failed to provide the user the
 right amount of context to make an informed decision.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func New(text string) error {
         return &errorString{text}
     }

--- a/_content/tour/eng/error-handling/example1.go
+++ b/_content/tour/eng/error-handling/example1.go
@@ -8,22 +8,22 @@ package main
 
 import "fmt"
 
-// http://golang.org/pkg/builtin/#error
+// https://golang.org/pkg/builtin/#error
 type error interface {
 	Error() string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 type errorString struct {
 	s string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 func (e *errorString) Error() string {
 	return e.s
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 // New returns an error that formats as the given text.
 func New(text string) error {
 	return &errorString{text}

--- a/_content/tour/eng/error-handling/example3.go
+++ b/_content/tour/eng/error-handling/example3.go
@@ -3,7 +3,7 @@
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0
 
-// http://golang.org/src/pkg/encoding/json/decode.go
+// https://golang.org/src/pkg/encoding/json/decode.go
 // Sample program to show how to implement a custom error type
 // based on the json package in the standard library.
 package main

--- a/_content/tour/eng/variables.article
+++ b/_content/tour/eng/variables.article
@@ -143,7 +143,7 @@ of integrity for these types of operations.
 
 ** Extra Reading
 
-- [[http://golang.org/ref/spec#Boolean_types][Built-In Types]]
+- [[https://golang.org/ref/spec#Boolean_types][Built-In Types]]
 - [[https://golang.org/doc/effective_go.html#variables][Variables]]
 - [[https://www.ardanlabs.com/blog/2013/08/gustavos-ieee-754-brain-teaser.html][Gustavo's IEEE-754 Brain Teaser]] - William Kennedy
 - [[https://www.youtube.com/watch?v=sFUSP8Au_PE][What's in a name]]

--- a/_content/tour/fre/error-handling.article
+++ b/_content/tour/fre/error-handling.article
@@ -39,7 +39,7 @@ Elles peuvent contenir n'importe quel état ou comportement.
 
 L'interface `error` est intégrée au langage.
 
-    // http://golang.org/pkg/builtin/#error
+    // https://golang.org/pkg/builtin/#error
     type error interface {
         Error() string
     }
@@ -52,12 +52,12 @@ Une raison clé à cela est que la gestion des erreurs est un aspect de mon appl
 et amélioré. Cette interface est le type que les applications Go doivent utiliser comme type de retour pour 
 la gestion des erreurs.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     type errorString struct {
         s string
     }
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func (e *errorString) Error() string {
         return e.s
     }
@@ -72,7 +72,7 @@ Il est important de se rappeler que l'implémentation de la méthode `Error()` s
 à la journalisation (log). Si un utilisateur a besoin d'analyser la chaîne renvoyée par cette méthode, cela signifie 
 que vous ne lui avez pas fourni suffisamment de contexte pour prendre une décision éclairée.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func New(text string) error {
         return &errorString{text}
     }

--- a/_content/tour/fre/error-handling/example1.go
+++ b/_content/tour/fre/error-handling/example1.go
@@ -8,22 +8,22 @@ package main
 
 import "fmt"
 
-// http://golang.org/pkg/builtin/#error
+// https://golang.org/pkg/builtin/#error
 type error interface {
 	Error() string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 type errorString struct {
 	s string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 func (e *errorString) Error() string {
 	return e.s
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 // New returns an error that formats as the given text.
 func New(text string) error {
 	return &errorString{text}

--- a/_content/tour/fre/error-handling/example3.go
+++ b/_content/tour/fre/error-handling/example3.go
@@ -3,7 +3,7 @@
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0
 
-// http://golang.org/src/pkg/encoding/json/decode.go
+// https://golang.org/src/pkg/encoding/json/decode.go
 // Sample program to show how to implement a custom error type
 // based on the json package in the standard library.
 package main

--- a/_content/tour/fre/variables.article
+++ b/_content/tour/fre/variables.article
@@ -128,7 +128,7 @@ d'opérations.
 
 ** Lectures Supplémentaires
 
-- [[http://golang.org/ref/spec#Boolean_types][Built-In Types]]
+- [[https://golang.org/ref/spec#Boolean_types][Built-In Types]]
 - [[https://golang.org/doc/effective_go.html#variables][Variables]]
 - [[https://www.ardanlabs.com/blog/2013/08/gustavos-ieee-754-brain-teaser.html][Gustavo's IEEE-754 Brain Teaser]] - William Kennedy
 - [[https://www.youtube.com/watch?v=sFUSP8Au_PE][What's in a name]]

--- a/_content/tour/ger/error-handling.article
+++ b/_content/tour/ger/error-handling.article
@@ -38,7 +38,7 @@ In Go sind Fehler einfach nur Werte, die alles sein können. Sie können jeden Z
 
 Die Fehlerschnittstelle ist in die Sprache integriert.
 
-    // http://golang.org/pkg/builtin/#error
+    // https://golang.org/pkg/builtin/#error
     type error interface {
         Error() string
     }
@@ -50,12 +50,12 @@ Ein wichtiger Aspekt von Go ist, dass die Fehlerbehandlung in einem entkoppelten
 Ein Hauptgrund dafür ist, dass die Fehlerbehandlung ein Aspekt der Anwendung ist, der anfälliger für Änderungen und Verbesserungen ist.
 Dieses Interface ist der Typ, den Go-Anwendungen als Rückgabetyp für die Fehlerbehandlung verwenden müssen.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     type errorString struct {
         s string
     }
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func (e *errorString) Error() string {
         return e.s
     }
@@ -72,7 +72,7 @@ der Interface Implementierung und der Protokollierung dient. Wenn ein Benutzer d
 zurückgegebene Zeichenkette analysieren muss, habt ihr es versäumt, dem Benutzer den richtigen
 Context zu liefern, damit er eine fundierte Entscheidung treffen kann.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func New(text string) error {
         return &errorString{text}
     }
@@ -438,4 +438,3 @@ Schreibt eine main Funktion um checkFalg aufzurufen und überprüft den Fehler u
 
 .play error-handling/exercise2.go
 .play error-handling/answer2.go
-

--- a/_content/tour/ger/error-handling/example1.go
+++ b/_content/tour/ger/error-handling/example1.go
@@ -8,22 +8,22 @@ package main
 
 import "fmt"
 
-// http://golang.org/pkg/builtin/#error
+// https://golang.org/pkg/builtin/#error
 type error interface {
 	Error() string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 type errorString struct {
 	s string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 func (e *errorString) Error() string {
 	return e.s
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 // New returns an error that formats as the given text.
 func New(text string) error {
 	return &errorString{text}

--- a/_content/tour/ger/error-handling/example3.go
+++ b/_content/tour/ger/error-handling/example3.go
@@ -3,7 +3,7 @@
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0
 
-// http://golang.org/src/pkg/encoding/json/decode.go
+// https://golang.org/src/pkg/encoding/json/decode.go
 // Sample program to show how to implement a custom error type
 // based on the json package in the standard library.
 package main

--- a/_content/tour/ger/variables.article
+++ b/_content/tour/ger/variables.article
@@ -141,7 +141,7 @@ der Integrität für diese Art von Operationen.
 
 ** Extra Lesen
 
-- [[http://golang.org/ref/spec#Boolean_types][Eingebaute Typen]]
+- [[https://golang.org/ref/spec#Boolean_types][Eingebaute Typen]]
 - [[https://golang.org/doc/effective_go.html#variables][Variablen]]
 - [[https://www.ardanlabs.com/blog/2013/08/gustavos-ieee-754-brain-teaser.html][Gustavo's IEEE-754 Brain Teaser]] - William Kennedy
 - [[https://www.youtube.com/watch?v=sFUSP8Au_PE][Was steckt in einem Namen]]

--- a/_content/tour/grc/error-handling.article
+++ b/_content/tour/grc/error-handling.article
@@ -40,7 +40,7 @@
 
 Η διεπαφή error είναι προεγκατεστημένη στην γλώσσα. 
 
-    // http://golang.org/pkg/builtin/#error
+    // https://golang.org/pkg/builtin/#error
     type error interface {
         Error() string
     }
@@ -55,12 +55,12 @@
 που οι εφαρμογές της Go πρέπει να χρησιμοποιούν ως τον τύπο επιστροφής, σχετικά με 
 την διαχείριση σφαλμάτων.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     type errorString struct {
         s string
     }
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func (e *errorString) Error() string {
         return e.s
     }
@@ -78,7 +78,7 @@
 επεξεργαστεί την συμβολοσειρά που επιστρέφει αυτή η μέθοδος τύπου, αυτό σημαίνει, ότι δεν έχει καταστεί 
 δυνατό να εφοδιαστεί με το κατάλληλο πλαίσιο αναφοράς, προκειμένου να παρει μια απόφαση.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func New(text string) error {
         return &errorString{text}
     }

--- a/_content/tour/grc/error-handling/example1.go
+++ b/_content/tour/grc/error-handling/example1.go
@@ -9,22 +9,22 @@ package main
 
 import "fmt"
 
-// http://golang.org/pkg/builtin/#error
+// https://golang.org/pkg/builtin/#error
 type error interface {
 	Error() string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 type errorString struct {
 	s string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 func (e *errorString) Error() string {
 	return e.s
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 // Η New επιστρέφει έναν error, που μορφοποιείται ως το δοσμένο κείμενο.
 func New(text string) error {
 	return &errorString{text}

--- a/_content/tour/grc/error-handling/example3.go
+++ b/_content/tour/grc/error-handling/example3.go
@@ -3,7 +3,7 @@
 // Όλα τα υλικά είναι αδειοδοτημένα υπό την Άδεια Apache Έκδοση 2.0, Ιανουάριος 2004
 // http://www.apache.org/licenses/LICENSE-2.0
 
-// http://golang.org/src/pkg/encoding/json/decode.go
+// https://golang.org/src/pkg/encoding/json/decode.go
 // Δείγμα προγράμματος, προκειμένου να παρουσιαστεί πως υλοποιείται ένας
 // εξειδικευμένος τύπος σφάλματος, με βάση το πακέτο json της βασικής
 // βιβλιοθήκης,

--- a/_content/tour/grc/variables.article
+++ b/_content/tour/grc/variables.article
@@ -146,7 +146,7 @@
 
 ** Πρόσθετα Αναγνώσματα
 
-- [[http://golang.org/ref/spec#Boolean_types][Προεγκατεστημένοι Τύποι Μεταβλητών]]    
+- [[https://golang.org/ref/spec#Boolean_types][Προεγκατεστημένοι Τύποι Μεταβλητών]]    
 - [[https://golang.org/doc/effective_go.html#variables][Μεταβλητές]]    
 - [[https://www.ardanlabs.com/blog/2013/08/gustavos-ieee-754-brain-teaser.html][Ο Γρίφος του Gustavo σχετικά με το πρότυπο IEEE-754]] - William Kennedy    
 - [[https://www.youtube.com/watch?v=sFUSP8Au_PE][Τι περιέχει ένα όνομα;]]    

--- a/_content/tour/ita/error-handling.article
+++ b/_content/tour/ita/error-handling.article
@@ -40,7 +40,7 @@ Possono mantenere qualsiasi stato o comportamento.
 
 L'interfaccia di errore è integrata nel linguaggio.
 
-    // http://golang.org/pkg/builtin/#error
+    // https://golang.org/pkg/builtin/#error
     type error interface {
         Error() string
     }
@@ -53,12 +53,12 @@ tramite questa interfaccia. Uno dei motivi principali di ciò è che la gestione
 un aspetto della mia applicazione più suscettibile a modifiche e miglioramenti.
 Questa interfaccia è il tipo che le applicazioni Go devono utilizzare come tipo restituito per la gestione degli errori.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     type errorString struct {
         s string
     }
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func (e *errorString) Error() string {
         return e.s
     }
@@ -76,7 +76,7 @@ Se un utente ha bisogno di analizzare la stringa restituita da questo metodo,
 hai fallito nel fornire all'utente la giusta quantità di contesto per prendere una decisione informata.
 
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func New(text string) error {
         return &errorString{text}
     }

--- a/_content/tour/ita/error-handling/example1.go
+++ b/_content/tour/ita/error-handling/example1.go
@@ -8,22 +8,22 @@ package main
 
 import "fmt"
 
-// http://golang.org/pkg/builtin/#error
+// https://golang.org/pkg/builtin/#error
 type error interface {
 	Error() string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 type errorString struct {
 	s string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 func (e *errorString) Error() string {
 	return e.s
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 // New returns an error that formats as the given text.
 func New(text string) error {
 	return &errorString{text}

--- a/_content/tour/ita/error-handling/example3.go
+++ b/_content/tour/ita/error-handling/example3.go
@@ -3,7 +3,7 @@
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0
 
-// http://golang.org/src/pkg/encoding/json/decode.go
+// https://golang.org/src/pkg/encoding/json/decode.go
 // Sample program to show how to implement a custom error type
 // based on the json package in the standard library.
 package main

--- a/_content/tour/ita/variables.article
+++ b/_content/tour/ita/variables.article
@@ -140,7 +140,7 @@ L'esecuzione di una conversione fornisce il massimo livello di integrità per qu
 
 ** Letture extra
 
-- [[http://golang.org/ref/spec#Boolean_types][Tipi incorporati]]
+- [[https://golang.org/ref/spec#Boolean_types][Tipi incorporati]]
 - [[https://golang.org/doc/effective_go.html#variables][Variabili]]
 - [[https://www.ardanlabs.com/blog/2013/08/gustavos-ieee-754-brain-teaser.html][Gustavo's IEEE-754 Brain Teaser]] - William Kennedy    
 - [[https://www.youtube.com/watch?v=sFUSP8Au_PE][Cosa c'è in un nome]]

--- a/_content/tour/per/error-handling.article
+++ b/_content/tour/per/error-handling.article
@@ -32,7 +32,7 @@
 
 رابط خطا به زبان داخلی تعبیه شده است.
 
-    // http://golang.org/pkg/builtin/#error
+    // https://golang.org/pkg/builtin/#error
     type error interface {
         Error() string
     }
@@ -41,12 +41,12 @@
 
 یک جنبه مهم در Go این است که مدیریت خطا از طریق این رابط در یک حالت جداگانه انجام می‌شود. دلیل اصلی این امر این است که مدیریت خطا یک جنبه از برنامه من است که بیشتر به تغییر و بهبود حساس است. این رابط نوعی است که برنامه‌های Go باید از آن به عنوان نوع بازگشتی برای مدیریت خطا استفاده کنند.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     type errorString struct {
         s string
     }
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func (e *errorString) Error() string {
         return e.s
     }
@@ -55,7 +55,7 @@
 
 مهم است به خاطر بیاورید که پیاده‌سازی متد Error به منظور پیاده‌سازی رابط و برای ثبت وقوع خطا استفاده می‌شود. اگر کاربری نیاز به تجزیه رشته ای که از این متد برگشت داده شده است داشته باشد، شما نتوانسته‌اید به کاربر مقدار مناسبی از متن را برای تصمیم اطلاع‌داری ارائه دهید.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func New(text string) error {
         return &errorString{text}
     }

--- a/_content/tour/per/error-handling/example1.go
+++ b/_content/tour/per/error-handling/example1.go
@@ -8,22 +8,22 @@ package main
 
 import "fmt"
 
-// http://golang.org/pkg/builtin/#error
+// https://golang.org/pkg/builtin/#error
 type error interface {
 	Error() string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 type errorString struct {
 	s string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 func (e *errorString) Error() string {
 	return e.s
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 // New returns an error that formats as the given text.
 func New(text string) error {
 	return &errorString{text}

--- a/_content/tour/per/error-handling/example3.go
+++ b/_content/tour/per/error-handling/example3.go
@@ -3,7 +3,7 @@
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0
 
-// http://golang.org/src/pkg/encoding/json/decode.go
+// https://golang.org/src/pkg/encoding/json/decode.go
 // Sample program to show how to implement a custom error type
 // based on the json package in the standard library.
 package main

--- a/_content/tour/per/variables.article
+++ b/_content/tour/per/variables.article
@@ -126,7 +126,7 @@ Go واقعاً یک بسته در کتابخانه استاندارد به نا
 
 ** خواندن موارد بیشتر
 
-- [[http://golang.org/ref/spec#Boolean_types][Built-In Types]]    
+- [[https://golang.org/ref/spec#Boolean_types][Built-In Types]]    
 - [[https://golang.org/doc/effective_go.html#variables][Variables]]    
 - [[https://www.ardanlabs.com/blog/2013/08/gustavos-ieee-754-brain-teaser.html][Gustavo's IEEE-754 Brain Teaser]] - William Kennedy    
 - [[https://www.youtube.com/watch?v=sFUSP8Au_PE][What's in a name]]    

--- a/_content/tour/pol/error-handling.article
+++ b/_content/tour/pol/error-handling.article
@@ -39,7 +39,7 @@ Mogą przechowywać dowolny stan lub zachowanie.
 
 Interfejs błędu (error) jest wbudowany w język.
 
-    // http://golang.org/pkg/builtin/#error
+    // https://golang.org/pkg/builtin/#error
     type error interface {
         Error() string
     }
@@ -52,12 +52,12 @@ stanie poprzez interfejs. Głównym powodem jest to, że obsługa błędów to a
 mojej aplikacji, który jest bardziej podatny na zmiany i ulepszenia. Ten interfejs
 jest typem, który muszą używać aplikacje Go jako typ zwracany do obsługi błędów.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     type errorString struct {
         s string
     }
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func (e *errorString) Error() string {
         return e.s
     }
@@ -73,7 +73,7 @@ Warto pamiętać, że implementacja metody Error służy do implementacji interf
 informacji o błędach. Jeśli użytkownik musi analizować łańcuch znaków zwracany przez tę metodę,
 oznacza to, że nie dostarczyłeś użytkownikowi odpowiedniej ilości kontekstu do podjęcia świadomej decyzji.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func New(text string) error {
         return &errorString{text}
     }

--- a/_content/tour/pol/error-handling/example1.go
+++ b/_content/tour/pol/error-handling/example1.go
@@ -8,22 +8,22 @@ package main
 
 import "fmt"
 
-// http://golang.org/pkg/builtin/#error
+// https://golang.org/pkg/builtin/#error
 type error interface {
 	Error() string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 type errorString struct {
 	s string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 func (e *errorString) Error() string {
 	return e.s
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 // New returns an error that formats as the given text.
 func New(text string) error {
 	return &errorString{text}

--- a/_content/tour/pol/error-handling/example3.go
+++ b/_content/tour/pol/error-handling/example3.go
@@ -3,7 +3,7 @@
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0
 
-// http://golang.org/src/pkg/encoding/json/decode.go
+// https://golang.org/src/pkg/encoding/json/decode.go
 // Sample program to show how to implement a custom error type
 // based on the json package in the standard library.
 package main

--- a/_content/tour/pol/variables.article
+++ b/_content/tour/pol/variables.article
@@ -137,7 +137,7 @@ Wykonywanie konwersji zapewnia najwyższy poziom integralności dla tego rodzaju
 
 ** Dodatkowe materiały
 
-- [[http://golang.org/ref/spec#Boolean_types][Built-In Types]]    
+- [[https://golang.org/ref/spec#Boolean_types][Built-In Types]]    
 - [[https://golang.org/doc/effective_go.html#variables][Variables]]    
 - [[https://www.ardanlabs.com/blog/2013/08/gustavos-ieee-754-brain-teaser.html][Gustavo's IEEE-754 Brain Teaser]] - William Kennedy    
 - [[https://www.youtube.com/watch?v=sFUSP8Au_PE][What's in a name]]    

--- a/_content/tour/por/error-handling.article
+++ b/_content/tour/por/error-handling.article
@@ -32,7 +32,7 @@ Em Go, os erros são apenas valores, então eles podem ser qualquer coisa que vo
 
 A interface de erro está incorporada na linguagem.
 
-    // http://golang.org/pkg/builtin/#error
+    // https://golang.org/pkg/builtin/#error
     type error interface {
         Error() string
     }
@@ -41,12 +41,12 @@ Por isso, parece ser um identificador não exportado. Qualquer valor concreto qu
 
 Um aspecto importante do Go é que o tratamento de erros é feito em um estado desacoplado por meio desta interface. Uma razão importante para isso é porque o tratamento de erros é um aspecto da minha aplicação que está mais suscetível a mudanças e melhorias. Esta interface é o tipo que as aplicações em Go devem usar como tipo de retorno para o tratamento de erros.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     type errorString struct {
         s string
     }
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func (e *errorString) Error() string {
         return e.s
     }
@@ -55,7 +55,7 @@ Este é o valor de erro mais comumente usado em programas Go. Ele é declarado n
 
 É importante lembrar que a implementação do método Error serve ao propósito de implementar a interface e para o registro de logs. Se algum usuário precisar analisar a string retornada por este método, você falhou em fornecer ao usuário a quantidade certa de contexto para tomar uma decisão informada.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func New(text string) error {
         return &errorString{text}
     }

--- a/_content/tour/por/error-handling/example1.go
+++ b/_content/tour/por/error-handling/example1.go
@@ -8,22 +8,22 @@ package main
 
 import "fmt"
 
-// http://golang.org/pkg/builtin/#error
+// https://golang.org/pkg/builtin/#error
 type error interface {
 	Error() string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 type errorString struct {
 	s string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 func (e *errorString) Error() string {
 	return e.s
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 // New returns an error that formats as the given text.
 func New(text string) error {
 	return &errorString{text}

--- a/_content/tour/por/error-handling/example3.go
+++ b/_content/tour/por/error-handling/example3.go
@@ -3,7 +3,7 @@
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0
 
-// http://golang.org/src/pkg/encoding/json/decode.go
+// https://golang.org/src/pkg/encoding/json/decode.go
 // Sample program to show how to implement a custom error type
 // based on the json package in the standard library.
 package main

--- a/_content/tour/por/variables.article
+++ b/_content/tour/por/variables.article
@@ -143,7 +143,7 @@ de integridade para esses tipos de operações.
 
 ** Leitura Extra
 
-- [[http://golang.org/ref/spec#Boolean_types][Tipos Básicos]]    
+- [[https://golang.org/ref/spec#Boolean_types][Tipos Básicos]]    
 - [[https://golang.org/doc/effective_go.html#variables][Variáveis]]    
 - [[https://www.ardanlabs.com/blog/2013/08/gustavos-ieee-754-brain-teaser.html][Gustavo's IEEE-754 Brain Teaser]] - William Kennedy    
 - [[https://www.youtube.com/watch?v=sFUSP8Au_PE][What's in a name]]    

--- a/_content/tour/rus/error-handling.article
+++ b/_content/tour/rus/error-handling.article
@@ -39,7 +39,7 @@
 
 error интерфейс  встроен в язык.
 
-    // http://golang.org/pkg/builtin/#error
+    // https://golang.org/pkg/builtin/#error
     type error interface {
         Error() string
     }
@@ -52,12 +52,12 @@ error интерфейс  встроен в язык.
 моего приложения, позволяющий приложению проще изменяться и улучшаться. Приложения Go
 должны возвращать error интерфейс для обработки ошибок.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     type errorString struct {
         s string
     }
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func (e *errorString) Error() string {
         return e.s
     }
@@ -74,7 +74,7 @@ error интерфейс  встроен в язык.
 это говорит о том, что вы не предоставили пользователю достаточно контекста
 для принятия информированного решения.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func New(text string) error {
         return &errorString{text}
     }

--- a/_content/tour/rus/error-handling/example1.go
+++ b/_content/tour/rus/error-handling/example1.go
@@ -8,22 +8,22 @@ package main
 
 import "fmt"
 
-// http://golang.org/pkg/builtin/#error
+// https://golang.org/pkg/builtin/#error
 type error interface {
 	Error() string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 type errorString struct {
 	s string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 func (e *errorString) Error() string {
 	return e.s
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 // New returns an error that formats as the given text.
 func New(text string) error {
 	return &errorString{text}

--- a/_content/tour/rus/error-handling/example3.go
+++ b/_content/tour/rus/error-handling/example3.go
@@ -3,7 +3,7 @@
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0
 
-// http://golang.org/src/pkg/encoding/json/decode.go
+// https://golang.org/src/pkg/encoding/json/decode.go
 // Sample program to show how to implement a custom error type
 // based on the json package in the standard library.
 package main

--- a/_content/tour/rus/variables.article
+++ b/_content/tour/rus/variables.article
@@ -142,7 +142,7 @@
 
 ** Дополнительное чтение
 
-- [[http://golang.org/ref/spec#Boolean_types][Встроенные Типы]]
+- [[https://golang.org/ref/spec#Boolean_types][Встроенные Типы]]
 - [[https://golang.org/doc/effective_go.html#variables][Переменные]]
 - [[https://www.ardanlabs.com/blog/2013/08/gustavos-ieee-754-brain-teaser.html][Загадка Густаво по IEEE-754]] - Уильям Кеннеди
 - [[https://www.youtube.com/watch?v=sFUSP8Au_PE][Что в имени]]

--- a/_content/tour/tur/error-handling.article
+++ b/_content/tour/tur/error-handling.article
@@ -40,7 +40,7 @@ Herhangi bir durumu veya davranışı sürdürebilirler.
 
 Hata arabirimi dilin içine yerleştirilmiştir.
 
-    // http://golang.org/pkg/builtin/#error
+    // https://golang.org/pkg/builtin/#error
     type error interface {
         Error() string
     }
@@ -53,12 +53,12 @@ Bunun ana nedenlerinden biri, hata işleminin, uygulamanızın değişikliklere 
 daha açık bir yönü olmasıdır. Bu arayüz, Go uygulamalarının hata işlemesi için dönüş türü 
 olarak kullanması gereken türdür.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     type errorString struct {
         s string
     }
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func (e *errorString) Error() string {
         return e.s
     }
@@ -74,7 +74,7 @@ günlüğe kaydetme amacına da hizmet eder. Eğer herhangi bir kullanıcının 
 diziyi çözümlemesi gerekiyorsa, kullanıcıya bilinçli bir karar vermek için yeterli bağlamı 
 sağlamada başarısız olmuşsunuz demektir.
 
-    // http://golang.org/src/pkg/errors/errors.go
+    // https://golang.org/src/pkg/errors/errors.go
     func New(text string) error {
         return &errorString{text}
     }

--- a/_content/tour/tur/error-handling/example1.go
+++ b/_content/tour/tur/error-handling/example1.go
@@ -8,22 +8,22 @@ package main
 
 import "fmt"
 
-// http://golang.org/pkg/builtin/#error
+// https://golang.org/pkg/builtin/#error
 type error interface {
 	Error() string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 type errorString struct {
 	s string
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 func (e *errorString) Error() string {
 	return e.s
 }
 
-// http://golang.org/src/pkg/errors/errors.go
+// https://golang.org/src/pkg/errors/errors.go
 // New returns an error that formats as the given text.
 func New(text string) error {
 	return &errorString{text}

--- a/_content/tour/tur/error-handling/example3.go
+++ b/_content/tour/tur/error-handling/example3.go
@@ -3,7 +3,7 @@
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0
 
-// http://golang.org/src/pkg/encoding/json/decode.go
+// https://golang.org/src/pkg/encoding/json/decode.go
 // Sample program to show how to implement a custom error type
 // based on the json package in the standard library.
 package main

--- a/_content/tour/tur/variables.article
+++ b/_content/tour/tur/variables.article
@@ -144,7 +144,7 @@ en yüksek bütünlüğü sağlar.
 
 ** Ekstra Okuma
 
-- [[http://golang.org/ref/spec#Boolean_types][Built-In Types]]    
+- [[https://golang.org/ref/spec#Boolean_types][Built-In Types]]    
 - [[https://golang.org/doc/effective_go.html#variables][Variables]]    
 - [[https://www.ardanlabs.com/blog/2013/08/gustavos-ieee-754-brain-teaser.html][Gustavo's IEEE-754 Brain Teaser]] - William Kennedy    
 - [[https://www.youtube.com/watch?v=sFUSP8Au_PE][What's in a name]]    


### PR DESCRIPTION
The PR replaces `http://golang.org` with `https://golang.org`. No need for unsecure links.