### PR TITLE
fix typos in articles

### DIFF
--- a/_content/tour/eng/generics-type-constraints.article
+++ b/_content/tour/eng/generics-type-constraints.article
@@ -99,7 +99,7 @@ method set of behavior.
     }
 
 A generic interface is declared where T is the type of value to be passed into a
-method named match. The interface also constrains its use to only values of userdefined
+method named match. The interface also constrains its use to only values of user-defined
 type person and food.
 
 When you look at the match function, there isn’t an obvious need to restrict the

--- a/_content/tour/eng/methods.article
+++ b/_content/tour/eng/methods.article
@@ -147,7 +147,7 @@ use of pointer semantics because the data dictates the data semantics and not th
 function.
 
 One exception to using value semantics is when you need to share a slice or map
-with a function that performs unmarshaling or decoding.
+with a function that performs unmarshalling or decoding.
 
 ** Data Semantic Guideline For Struct Types
 

--- a/_content/tour/eng/slices.article
+++ b/_content/tour/eng/slices.article
@@ -105,7 +105,7 @@ to move the data around my program. This includes declaring fields on a type.
 This goes for all of Go’s internal data structures (slices, maps, channels, interfaces, and functions).
 
 One reason to switch to pointer semantics is if you need to share the slice for a
-decoding or unmarshaling operation. Using pointers for these types of operations
+decoding or unmarshalling operation. Using pointers for these types of operations
 are ok, but document this if it’s not obvious.
 
 ** Contiguous Memory Layout


### PR DESCRIPTION
I noticed some spell-check errors while I was doing the Ukrainian translation.
This PR corrects some minor typos:
`unmarshaling` -> `unmarshalling`
`userdefined` -> `user-defined`