### PR TITLE
Use secure links for Go Blog and YouTube

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ _William Kennedy is a managing partner at Ardan Labs in Miami, Florida. Ardan La
 
 _**Video Training**_  
 [Ultimate Go Video](https://education.ardanlabs.com)  
-[Ardan Labs YouTube Channel](http://youtube.ardanlabs.com/)
+[Ardan Labs YouTube Channel](https://youtube.ardanlabs.com/)
 
 _**Blog**_  
 [Going Go](https://www.ardanlabs.com/blog/)    

--- a/_content/tour/eng/channels.article
+++ b/_content/tour/eng/channels.article
@@ -137,7 +137,7 @@ state of a channel can be `nil`, `open` or `closed`.
 
 - [[https://www.ardanlabs.com/blog/2017/10/the-behavior-of-channels.html][The Behavior Of Channels]] - William Kennedy  
 - [[https://golang.org/ref/mem#tmp_7][Channel Communication]]    
-- [[http://blog.golang.org/share-memory-by-communicating][Share Memory By Communicating]] - Andrew Gerrand    
+- [[https://blog.golang.org/share-memory-by-communicating][Share Memory By Communicating]] - Andrew Gerrand    
 - [[https://www.ardanlabs.com/blog/2014/02/the-nature-of-channels-in-go.html][The Nature Of Channels In Go]] - William Kennedy    
 - [[http://matt-welsh.blogspot.com/2010/07/retrospective-on-seda.html][A Retrospective on SEDA]] - Matt Welsh    
 - [[https://www.youtube.com/watch?v=KBZlN0izeiY][Understanding Channels]] - Kavya Joshi    

--- a/_content/tour/eng/data_race.article
+++ b/_content/tour/eng/data_race.article
@@ -549,7 +549,7 @@ This content is provided by Scott Meyers from his talk in 2014 at Dive:
 
 - [[http://www.drdobbs.com/parallel/eliminate-false-sharing/217500206][Eliminate False Sharing]] - Herb Sutter    
 - [[https://golang.org/ref/mem][The Go Memory Model]]    
-- [[http://blog.golang.org/race-detector][Introducing the Go Race Detector]] - Dmitry Vyukov and Andrew Gerrand    
+- [[https://blog.golang.org/race-detector][Introducing the Go Race Detector]] - Dmitry Vyukov and Andrew Gerrand    
 - [[https://www.ardanlabs.com/blog/2013/09/detecting-race-conditions-with-go.html][Detecting Race Conditions With Go]] - William Kennedy    
 - [[https://golang.org/doc/articles/race_detector.html][Data Race Detector]]    
 

--- a/_content/tour/eng/welcome.article
+++ b/_content/tour/eng/welcome.article
@@ -161,7 +161,7 @@ increase Go adoption through diversity.
 *Video* *Training*
 
 - [[https://education.ardanlabs.com/][Ultimate Go Video]]
-- [[http://youtube.ardanlabs.com/][Ardan Labs YouTube Channel]]
+- [[https://youtube.ardanlabs.com/][Ardan Labs YouTube Channel]]
 
 *Blog*
 

--- a/_content/tour/fre/channels.article
+++ b/_content/tour/fre/channels.article
@@ -134,7 +134,7 @@ L'état d'une Channel peut être `nil`, `ouvert` ou `fermé`.
 
 - [[https://www.ardanlabs.com/blog/2017/10/the-behavior-of-channels.html][The Behavior Of Channels]] - William Kennedy  
 - [[https://golang.org/ref/mem#tmp_7][Channel Communication]]    
-- [[http://blog.golang.org/share-memory-by-communicating][Share Memory By Communicating]] - Andrew Gerrand    
+- [[https://blog.golang.org/share-memory-by-communicating][Share Memory By Communicating]] - Andrew Gerrand    
 - [[https://www.ardanlabs.com/blog/2014/02/the-nature-of-channels-in-go.html][The Nature Of Channels In Go]] - William Kennedy    
 - [[http://matt-welsh.blogspot.com/2010/07/retrospective-on-seda.html][A Retrospective on SEDA]] - Matt Welsh    
 - [[https://www.youtube.com/watch?v=KBZlN0izeiY][Understanding Channels]] - Kavya Joshi    

--- a/_content/tour/fre/data_race.article
+++ b/_content/tour/fre/data_race.article
@@ -537,7 +537,7 @@ Ce contenu est tiré de la conférence donnée par Scott Meyers à Dive en 2014 
 
 - [[http://www.drdobbs.com/parallel/eliminate-false-sharing/217500206][Eliminate False Sharing]] - Herb Sutter    
 - [[https://golang.org/ref/mem][The Go Memory Model]]    
-- [[http://blog.golang.org/race-detector][Introducing the Go Race Detector]] - Dmitry Vyukov and Andrew Gerrand    
+- [[https://blog.golang.org/race-detector][Introducing the Go Race Detector]] - Dmitry Vyukov and Andrew Gerrand    
 - [[https://www.ardanlabs.com/blog/2013/09/detecting-race-conditions-with-go.html][Detecting Race Conditions With Go]] - William Kennedy    
 - [[https://golang.org/doc/articles/race_detector.html][Data Race Detector]]    
 

--- a/_content/tour/fre/welcome.article
+++ b/_content/tour/fre/welcome.article
@@ -162,7 +162,7 @@ augmenter l’adoption de Go grâce à la diversité.
 *Video* *Formation*
 
 - [[https://education.ardanlabs.com/][Ultimate Go Video]]
-- [[http://youtube.ardanlabs.com/][Ardan Labs YouTube Channel]]
+- [[https://youtube.ardanlabs.com/][Ardan Labs YouTube Channel]]
 
 *Blog*
 

--- a/_content/tour/ger/channels.article
+++ b/_content/tour/ger/channels.article
@@ -138,7 +138,7 @@ Der Zustand eines Channels kann null (nil), offen oder geschlossen sein.
 
 - [[https://www.ardanlabs.com/blog/2017/10/the-behavior-of-channels.html][Das Verhalten von Channels]] - William Kennedy
 - [[https://golang.org/ref/mem#tmp_7][Channel-Kommunikation]]
-- [[http://blog.golang.org/share-memory-by-communicating][Gemeinsame Erinnerung durch Kommunikation]] - Andrew Gerrand
+- [[https://blog.golang.org/share-memory-by-communicating][Gemeinsame Erinnerung durch Kommunikation]] - Andrew Gerrand
 - [[https://www.ardanlabs.com/blog/2014/02/the-nature-of-channels-in-go.html][Die Natur von Channels in Go]] - William Kennedy
 - [[http://matt-welsh.blogspot.com/2010/07/retrospective-on-seda.html][Eine Retrospektive zu SEDA]] - Matt Welsh
 - [[https://www.youtube.com/watch?v=KBZlN0izeiY][Das Verständnis von Channels]] - Kavya Joshi

--- a/_content/tour/ger/data_race.article
+++ b/_content/tour/ger/data_race.article
@@ -560,7 +560,7 @@ Dieser Inhalt wird von Scott Meyers aus seinem Vortrag im Jahr 2014 bei Dive ber
 
 - [[http://www.drdobbs.com/parallel/eliminate-false-sharing/217500206][Falsches Teilen beseitigen]] - Herb Sutter
 - [[https://golang.org/ref/mem][Das Go-Speicher-Modell]]
-- [[http://blog.golang.org/race-detector][Einführung in den Go-Race-Detektor]] - Dmitry Vyukov und Andrew Gerrand
+- [[https://blog.golang.org/race-detector][Einführung in den Go-Race-Detektor]] - Dmitry Vyukov und Andrew Gerrand
 - [[https://www.ardanlabs.com/blog/2013/09/detecting-race-conditions-with-go.html][Erkennung von Rennzuständen mit Go]] - William Kennedy
 - [[https://golang.org/doc/articles/race_detector.html][Data Race Detector]]
 

--- a/_content/tour/ger/welcome.article
+++ b/_content/tour/ger/welcome.article
@@ -158,7 +158,7 @@ Go-Akzeptanz durch Vielfalt einsetzt.
 *Video* *Schulung*
 
 - [[https://education.ardanlabs.com/][Ultimate Go Video]]
-- [[http://youtube.ardanlabs.com/][Ardan Labs YouTube-Kanal]]
+- [[https://youtube.ardanlabs.com/][Ardan Labs YouTube-Kanal]]
 
 *Blog*
 

--- a/_content/tour/grc/channels.article
+++ b/_content/tour/grc/channels.article
@@ -156,7 +156,7 @@
 
 - [[https://www.ardanlabs.com/blog/2017/10/the-behavior-of-channels.html][Η Συμπεριφορά Καναλιών Επικοινωνίας]] - William Kennedy  
 - [[https://golang.org/ref/mem#tmp_7][Κανάλια Επικοινωνίας]]    
-- [[http://blog.golang.org/share-memory-by-communicating][Κοινή Χρήση Μνήμης Μέσω Επικοινωνίας]] - Andrew Gerrand    
+- [[https://blog.golang.org/share-memory-by-communicating][Κοινή Χρήση Μνήμης Μέσω Επικοινωνίας]] - Andrew Gerrand    
 - [[https://www.ardanlabs.com/blog/2014/02/the-nature-of-channels-in-go.html][Η Φύση των Καναλιών στην Go]] - William Kennedy    
 - [[http://matt-welsh.blogspot.com/2010/07/retrospective-on-seda.html][Μια Αναδρομή στην SEDA]] - Matt Welsh    
 - [[https://www.youtube.com/watch?v=KBZlN0izeiY][Κατανοώντας τα Κανάλια Επικοινωνίας]] - Kavya Joshi    

--- a/_content/tour/grc/data_race.article
+++ b/_content/tour/grc/data_race.article
@@ -580,7 +580,7 @@ Mutex δύο φορές στην ίδια συνάρτηση, μπορεί να 
 
 - [[http://www.drdobbs.com/parallel/eliminate-false-sharing/217500206][Εξάλειψη Εσφαλμένου Διαμοιρασμού]] - Herb Sutter    
 - [[https://golang.org/ref/mem][Το Υπόδειγμα Μνήμης της Go]]    
-- [[http://blog.golang.org/race-detector][Παρουσιάζοντας τον Ανιχνευτή Ανταγωνισμού για Δεδομένα της Go]] - Dmitry Vyukov and Andrew Gerrand    
+- [[https://blog.golang.org/race-detector][Παρουσιάζοντας τον Ανιχνευτή Ανταγωνισμού για Δεδομένα της Go]] - Dmitry Vyukov and Andrew Gerrand    
 - [[https://www.ardanlabs.com/blog/2013/09/detecting-race-conditions-with-go.html][Ανιχνεύοντας Συνθήκες Ανταγωνισμού για Δεδομένα με την Go]] - William Kennedy    
 - [[https://golang.org/doc/articles/race_detector.html][Ανιχνευτής Ανταγωνισμού για Δεδομένα]]    
 

--- a/_content/tour/grc/welcome.article
+++ b/_content/tour/grc/welcome.article
@@ -160,7 +160,7 @@ Ardan Labs ([[https://www.ardanlabs.com][www.ardanlabs.com]])
 *Εκπαιδευτικά* *Video*
 
 - [[https://education.ardanlabs.com/][Video Απόλυτης Go]]
-- [[http://youtube.ardanlabs.com/][το Κανάλι των Ardan Labs στο YouTube]]
+- [[https://youtube.ardanlabs.com/][το Κανάλι των Ardan Labs στο YouTube]]
 
 *Blog*
 

--- a/_content/tour/ita/channels.article
+++ b/_content/tour/ita/channels.article
@@ -125,7 +125,7 @@ Il comportamento di un channel è direttamente influenzato dal suo `State` corre
 
 - [[https://www.ardanlabs.com/blog/2017/10/the-behavior-of-channels.html][The Behavior Of Channels]] - William Kennedy
 - [[https://golang.org/ref/mem#tmp_7][Channel Communication]]
-- [[http://blog.golang.org/share-memory-by-communicating][Share Memory By Communicating]] - Andrew Gerrand
+- [[https://blog.golang.org/share-memory-by-communicating][Share Memory By Communicating]] - Andrew Gerrand
 - [[https://www.ardanlabs.com/blog/2014/02/the-nature-of-channels-in-go.html][The Nature Of Channels In Go]] - William Kennedy
 - [[http://matt-welsh.blogspot.com/2010/07/retrospective-on-seda.html][A Retrospective on SEDA]] - Matt Welsh
 - [[https://www.youtube.com/watch?v=KBZlN0izeiY][Understanding Channels]] - Kavya Joshi

--- a/_content/tour/ita/data_race.article
+++ b/_content/tour/ita/data_race.article
@@ -552,7 +552,7 @@ Questo contenuto è fornito da Scott Meyers dal suo talk nel 2014 a Dive:
 
 - [[http://www.drdobbs.com/parallel/eliminate-false-sharing/217500206][Eliminate False Sharing]] - Herb Sutter    
 - [[https://golang.org/ref/mem][The Go Memory Model]]    
-- [[http://blog.golang.org/race-detector][Introducing the Go Race Detector]] - Dmitry Vyukov and Andrew Gerrand    
+- [[https://blog.golang.org/race-detector][Introducing the Go Race Detector]] - Dmitry Vyukov and Andrew Gerrand    
 - [[https://www.ardanlabs.com/blog/2013/09/detecting-race-conditions-with-go.html][Detecting Race Conditions With Go]] - William Kennedy    
 - [[https://golang.org/doc/articles/race_detector.html][Data Race Detector]]    
 

--- a/_content/tour/ita/welcome.article
+++ b/_content/tour/ita/welcome.article
@@ -160,7 +160,7 @@ aumentare l' adozione di Go attraverso la diversità.
 *Video* *Training*
 
 - [[https://education.ardanlabs.com/][Ultimate Go Video]]
-- [[http://youtube.ardanlabs.com/][Ardan Labs YouTube Channel]]
+- [[https://youtube.ardanlabs.com/][Ardan Labs YouTube Channel]]
 
 *Blog*
 

--- a/_content/tour/per/channels.article
+++ b/_content/tour/per/channels.article
@@ -93,7 +93,7 @@
 
 - [[https://www.ardanlabs.com/blog/2017/10/the-behavior-of-channels.html][The Behavior Of Channels]] - William Kennedy  
 - [[https://golang.org/ref/mem#tmp_7][Channel Communication]]    
-- [[http://blog.golang.org/share-memory-by-communicating][Share Memory By Communicating]] - Andrew Gerrand    
+- [[https://blog.golang.org/share-memory-by-communicating][Share Memory By Communicating]] - Andrew Gerrand    
 - [[https://www.ardanlabs.com/blog/2014/02/the-nature-of-channels-in-go.html][The Nature Of Channels In Go]] - William Kennedy    
 - [[http://matt-welsh.blogspot.com/2010/07/retrospective-on-seda.html][A Retrospective on SEDA]] - Matt Welsh    
 - [[https://www.youtube.com/watch?v=KBZlN0izeiY][Understanding Channels]] - Kavya Joshi    

--- a/_content/tour/per/data_race.article
+++ b/_content/tour/per/data_race.article
@@ -480,7 +480,7 @@ API اتمیک‌ها به شکل زیر است:
 
 - [[http://www.drdobbs.com/parallel/eliminate-false-sharing/217500206][Eliminate False Sharing]] - Herb Sutter    
 - [[https://golang.org/ref/mem][The Go Memory Model]]    
-- [[http://blog.golang.org/race-detector][Introducing the Go Race Detector]] - Dmitry Vyukov and Andrew Gerrand    
+- [[https://blog.golang.org/race-detector][Introducing the Go Race Detector]] - Dmitry Vyukov and Andrew Gerrand    
 - [[https://www.ardanlabs.com/blog/2013/09/detecting-race-conditions-with-go.html][Detecting Race Conditions With Go]] - William Kennedy    
 - [[https://golang.org/doc/articles/race_detector.html][Data Race Detector]]    
 

--- a/_content/tour/per/welcome.article
+++ b/_content/tour/per/welcome.article
@@ -129,7 +129,7 @@ Playground از آخرین نسخه پایدار Go استفاده می‌کند
 *آموزش* *ویدئویی*
 
 - [[https://education.ardanlabs.com/][Ultimate Go Video]]
-- [[http://youtube.ardanlabs.com/][Ardan Labs YouTube Channel]]
+- [[https://youtube.ardanlabs.com/][Ardan Labs YouTube Channel]]
 
 *وبلاگ*
 

--- a/_content/tour/pol/channels.article
+++ b/_content/tour/pol/channels.article
@@ -133,7 +133,7 @@ Zachowanie kanału jest bezpośrednio wpływane przez jego aktualny stan. Stan k
 
 - [[https://www.ardanlabs.com/blog/2017/10/the-behavior-of-channels.html][The Behavior Of Channels]] - William Kennedy  
 - [[https://golang.org/ref/mem#tmp_7][Channel Communication]]    
-- [[http://blog.golang.org/share-memory-by-communicating][Share Memory By Communicating]] - Andrew Gerrand    
+- [[https://blog.golang.org/share-memory-by-communicating][Share Memory By Communicating]] - Andrew Gerrand    
 - [[https://www.ardanlabs.com/blog/2014/02/the-nature-of-channels-in-go.html][The Nature Of Channels In Go]] - William Kennedy    
 - [[http://matt-welsh.blogspot.com/2010/07/retrospective-on-seda.html][A Retrospective on SEDA]] - Matt Welsh    
 - [[https://www.youtube.com/watch?v=KBZlN0izeiY][Understanding Channels]] - Kavya Joshi    

--- a/_content/tour/pol/data_race.article
+++ b/_content/tour/pol/data_race.article
@@ -546,7 +546,7 @@ Treść ta pochodzi od Scotta Meyersa z jego wystąpienia w 2014 roku na konfere
 
 - [[http://www.drdobbs.com/parallel/eliminate-false-sharing/217500206][Eliminate False Sharing]] - Herb Sutter    
 - [[https://golang.org/ref/mem][The Go Memory Model]]    
-- [[http://blog.golang.org/race-detector][Introducing the Go Race Detector]] - Dmitry Vyukov and Andrew Gerrand    
+- [[https://blog.golang.org/race-detector][Introducing the Go Race Detector]] - Dmitry Vyukov and Andrew Gerrand    
 - [[https://www.ardanlabs.com/blog/2013/09/detecting-race-conditions-with-go.html][Detecting Race Conditions With Go]] - William Kennedy    
 - [[https://golang.org/doc/articles/race_detector.html][Data Race Detector]]    
 

--- a/_content/tour/pol/welcome.article
+++ b/_content/tour/pol/welcome.article
@@ -155,7 +155,7 @@ założycielem GoBridge, które działa na rzecz zwiększenia różnorodności w
 *Video* *Szkolenia*
 
 - [[https://education.ardanlabs.com/][Ultimate Go Video]]
-- [[http://youtube.ardanlabs.com/][Ardan Labs YouTube Channel]]
+- [[https://youtube.ardanlabs.com/][Ardan Labs YouTube Channel]]
 
 *Blog*
 

--- a/_content/tour/por/channels.article
+++ b/_content/tour/por/channels.article
@@ -139,7 +139,7 @@ O `estado` de um canal pode ser `nulo`, `aberto` ou `fechado`.
 
 - [[https://www.ardanlabs.com/blog/2017/10/the-behavior-of-channels.html][The Behavior Of Channels]] - William Kennedy
 - [[https://golang.org/ref/mem#tmp_7][Channel Communication]]
-- [[http://blog.golang.org/share-memory-by-communicating][Share Memory By Communicating]] - Andrew Gerrand
+- [[https://blog.golang.org/share-memory-by-communicating][Share Memory By Communicating]] - Andrew Gerrand
 - [[https://www.ardanlabs.com/blog/2014/02/the-nature-of-channels-in-go.html][The Nature Of Channels In Go]] - William Kennedy
 - [[http://matt-welsh.blogspot.com/2010/07/retrospective-on-seda.html][A Retrospective on SEDA]] - Matt Welsh
 - [[https://www.youtube.com/watch?v=KBZlN0izeiY][Understanding Channels]] - Kavya Joshi

--- a/_content/tour/por/data_race.article
+++ b/_content/tour/por/data_race.article
@@ -553,7 +553,7 @@ Este conteúdo é fornecido por Scott Meyers de sua palestra em 2014 na Dive.:
 
 - [[http://www.drdobbs.com/parallel/eliminate-false-sharing/217500206][Eliminate False Sharing]] - Herb Sutter    
 - [[https://golang.org/ref/mem][The Go Memory Model]]    
-- [[http://blog.golang.org/race-detector][Introducing the Go Race Detector]] - Dmitry Vyukov and Andrew Gerrand    
+- [[https://blog.golang.org/race-detector][Introducing the Go Race Detector]] - Dmitry Vyukov and Andrew Gerrand    
 - [[https://www.ardanlabs.com/blog/2013/09/detecting-race-conditions-with-go.html][Detecting Race Conditions With Go]] - William Kennedy    
 - [[https://golang.org/doc/articles/race_detector.html][Data Race Detector]]    
 

--- a/_content/tour/por/welcome.article
+++ b/_content/tour/por/welcome.article
@@ -162,7 +162,7 @@ para aumentar a adoção do Go por meio da diversidade.
 *Treinamento* *em* *Vídeo*
 
 - [[https://education.ardanlabs.com/][Vídeo Ultimate Go]]
-- [[http://youtube.ardanlabs.com/][Canal no Youtube da Ardan Labs]]
+- [[https://youtube.ardanlabs.com/][Canal no Youtube da Ardan Labs]]
 
 *Blog*
 

--- a/_content/tour/rus/channels.article
+++ b/_content/tour/rus/channels.article
@@ -136,7 +136,7 @@
 
 - [[https://www.ardanlabs.com/blog/2017/10/the-behavior-of-channels.html][The Behavior Of Channels]] - Уильям Кеннеди  
 - [[https://golang.org/ref/mem#tmp_7][Коммуникация каналов]]    
-- [[http://blog.golang.org/share-memory-by-communicating][Делимся памятью, общаясь]] - Эндрю Джерранд    
+- [[https://blog.golang.org/share-memory-by-communicating][Делимся памятью, общаясь]] - Эндрю Джерранд    
 - [[https://www.ardanlabs.com/blog/2014/02/the-nature-of-channels-in-go.html][Природа каналов в Go]] - Уильям Кеннеди    
 - [[http://matt-welsh.blogspot.com/2010/07/retrospective-on-seda.html][Ретроспектива SEDA]] - Мэтт Уэлш    
 - [[https://www.youtube.com/watch?v=KBZlN0izeiY][Понимание каналов]] - Kavya Joshi    

--- a/_content/tour/rus/data_race.article
+++ b/_content/tour/rus/data_race.article
@@ -539,7 +539,7 @@ API для атомиков выглядит следующим образом:
 
 - [[http://www.drdobbs.com/parallel/eliminate-false-sharing/217500206][Eliminate False Sharing]] - Херб Саттер    
 - [[https://golang.org/ref/mem][Модель памяти Go]]    
-- [[http://blog.golang.org/race-detector][Introducing the Go Race Detector]] - Дмитрий Вьюков и Эндрю Герранд    
+- [[https://blog.golang.org/race-detector][Introducing the Go Race Detector]] - Дмитрий Вьюков и Эндрю Герранд    
 - [[https://www.ardanlabs.com/blog/2013/09/detecting-race-conditions-with-go.html][Detecting Race Conditions With Go]] - Уильям Кеннеди    
 - [[https://golang.org/doc/articles/race_detector.html][Детектор состояний гонки данных]]    
 

--- a/_content/tour/rus/welcome.article
+++ b/_content/tour/rus/welcome.article
@@ -154,7 +154,7 @@ Ardan Labs работает как со стартапами, так и с ко�
 *Обучающие* *видео*
 
 - [[https://education.ardanlabs.com/][Ultimate Go Video]]
-- [[http://youtube.ardanlabs.com/][Ardan Labs YouTube Channel]]
+- [[https://youtube.ardanlabs.com/][Ardan Labs YouTube Channel]]
 
 *Блог*
 

--- a/_content/tour/tur/channels.article
+++ b/_content/tour/tur/channels.article
@@ -136,7 +136,7 @@ durumu `nil`, `açık` veya `kapalı` olabilir.
 
 - [[https://www.ardanlabs.com/blog/2017/10/the-behavior-of-channels.html][The Behavior Of Channels]] - William Kennedy  
 - [[https://golang.org/ref/mem#tmp_7][Channel Communication]]    
-- [[http://blog.golang.org/share-memory-by-communicating][Share Memory By Communicating]] - Andrew Gerrand    
+- [[https://blog.golang.org/share-memory-by-communicating][Share Memory By Communicating]] - Andrew Gerrand    
 - [[https://www.ardanlabs.com/blog/2014/02/the-nature-of-channels-in-go.html][The Nature Of Channels In Go]] - William Kennedy    
 - [[http://matt-welsh.blogspot.com/2010/07/retrospective-on-seda.html][A Retrospective on SEDA]] - Matt Welsh    
 - [[https://www.youtube.com/watch?v=KBZlN0izeiY][Understanding Channels]] - Kavya Joshi    

--- a/_content/tour/tur/data_race.article
+++ b/_content/tour/tur/data_race.article
@@ -544,7 +544,7 @@ Bu içerik, Scott Meyers'ın 2014 yılındaki Dive konuşmasından alınmıştı
 
 - [[http://www.drdobbs.com/parallel/eliminate-false-sharing/217500206][Eliminate False Sharing]] - Herb Sutter    
 - [[https://golang.org/ref/mem][The Go Memory Model]]    
-- [[http://blog.golang.org/race-detector][Introducing the Go Race Detector]] - Dmitry Vyukov and Andrew Gerrand    
+- [[https://blog.golang.org/race-detector][Introducing the Go Race Detector]] - Dmitry Vyukov and Andrew Gerrand    
 - [[https://www.ardanlabs.com/blog/2013/09/detecting-race-conditions-with-go.html][Detecting Race Conditions With Go]] - William Kennedy    
 - [[https://golang.org/doc/articles/race_detector.html][Data Race Detector]]    
 

--- a/_content/tour/tur/welcome.article
+++ b/_content/tour/tur/welcome.article
@@ -155,7 +155,7 @@ kurucu üyelerindendir.
 *Video* *Eğitim*
 
 - [[https://education.ardanlabs.com/][Ultimate Go Video]]
-- [[http://youtube.ardanlabs.com/][Ardan Labs YouTube Kanalı]]
+- [[https://youtube.ardanlabs.com/][Ardan Labs YouTube Kanalı]]
 
 *Blog*
 


### PR DESCRIPTION
The PR replaces `http://blog.golang.org` with `https://blog.golang.org`, `http://youtube.ardanlabs.com/` with `https://youtube.ardanlabs.com/`.